### PR TITLE
linux build and brrr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,9 @@ mingw-debug:
 	IF NOT EXIST "bin" MD "bin"
 	"$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -I"include/boinc/windows" -L"lib" -lboinc_api -lboinc -luser32 -m64 -O0 -Xcompiler -static-libgcc -Xcompiler -static-libstdc+ -Xcompiler -g
 
+linux:
+	mkdir -p bin
+	nvcc src/main.cu -o bin/slime-clusters -Iinclude/boinc -Llib -lboinc_api -lboinc
+
 clean:
 	IF EXIST "bin" RD /S /Q "bin"

--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,24 @@
 NVCC=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.0
 VCVARS=C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat
 
-msvc:
+windows:
 	IF NOT EXIST "bin" MD "bin"
 	"$(VCVARS)" && "$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -I"include/boinc/windows" -L"lib" -lboinc_api -lboinc -luser32 -m64 -O3
 
-msvc-debug:
+windows-debug:
 	IF NOT EXIST "bin" MD "bin"
 	"$(VCVARS)" && "$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -I"include/boinc/windows" -L"lib" -lboinc_api -lboinc -luser32 -m64 -O0 -Xcompiler /Zi -Xcompiler /Fdbin// -Xlinker /DEBUG:FULL
 
-mingw:
-	IF NOT EXIST "bin" MD "bin"
-	"$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -I"include/boinc/windows" -L"lib" -lboinc_api -lboinc -luser32 -m64 -O3 -Xcompiler -static-libgcc -Xcompiler -static-libstdc+
-
-mingw-debug:
-	IF NOT EXIST "bin" MD "bin"
-	"$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -I"include/boinc/windows" -L"lib" -lboinc_api -lboinc -luser32 -m64 -O0 -Xcompiler -static-libgcc -Xcompiler -static-libstdc+ -Xcompiler -g
-
 linux:
-	mkdir -p bin
-	nvcc src/main.cu -o bin/slime-clusters -Iinclude/boinc -Llib -lboinc_api -lboinc
+	mkdir -p "bin"
+	"$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -L"lib" -lboinc_api -lboinc -m64 -O3 -Xcompiler -static-libgcc -Xcompiler -static-libstdc+
 
-clean:
+linux-debug:
+	mkdir -p "bin"
+	"$(NVCC)/bin/nvcc" "src/main.cu" -o="bin/slime-clusters" -Wno-deprecated-gpu-targets -I"include/boinc" -L"lib" -lboinc_api -lboinc -m64 -O0 -Xcompiler -static-libgcc -Xcompiler -static-libstdc+ -Xcompiler -g
+	
+windows-clean:
 	IF EXIST "bin" RD /S /Q "bin"
+	
+linux-clean:
+	rm -rf "bin"

--- a/src/main.cu
+++ b/src/main.cu
@@ -144,7 +144,7 @@ __global__ void kernel(uint64_t block_count, uint64_t offset, uint64_t *collecto
         // Stack is left empty after every call to explore_cluster(...), so there's no need to clear it here.
         Cluster cluster = explore_cluster(cache, stack, rand, world_seed, chunk_x, chunk_z);
         if(cluster.get_size() >= c_min_cluster_size) {
-            uint64_t collector_idx = atomicAdd(collector_size, 1);
+            uint64_t collector_idx = atomicAdd(static_cast<unsigned long long *>(collector_size), 1);
             collector[collector_idx] = cluster;
         }
     }

--- a/src/main.cu
+++ b/src/main.cu
@@ -132,10 +132,13 @@ __global__ void kernel(uint64_t block_count, uint64_t offset, uint64_t *collecto
     Stack<Offset> stack = Stack<Offset>::wrap(stack_buffer, STACK_SIZE);
     JavaRandom rand = JavaRandom();
 
-    for(uint64_t i = 0; i < chunks_here; i++) {
-        uint64_t chunk_idx = i + starting_chunk;
-        int32_t chunk_x = (chunk_idx / (c_search_region_extents * 2)) - c_search_region_extents;
-        int32_t chunk_z = (chunk_idx % (c_search_region_extents * 2)) - c_search_region_extents;
+    for(uint64_t i = 0; i < chunks_here; i += 4) {
+        uint64_t chunk_idx = (i & ~4ULL) + starting_chunk;
+        int32_t chunk_x = chunk_idx / (c_search_region_extents * 2);
+        int32_t chunk_z = chunk_idx % (c_search_region_extents * 2);
+        chunk_z += (chunk_x % 8) ^ ((i % 8) / 4 * 7);
+        chunk_x -= c_search_region_extents;
+        chunk_z -= c_search_region_extents;
 
         cache.clear();
         // Stack is left empty after every call to explore_cluster(...), so there's no need to clear it here.

--- a/src/main.cu
+++ b/src/main.cu
@@ -136,9 +136,10 @@ __global__ void kernel(uint64_t block_count, uint64_t offset, uint64_t *collecto
         uint64_t chunk_idx = (i & ~4ULL) + starting_chunk;
         int32_t chunk_x = chunk_idx / (c_search_region_extents * 2);
         int32_t chunk_z = chunk_idx % (c_search_region_extents * 2);
-        chunk_z += (chunk_x % 8) ^ ((i % 8) / 4 * 7);
-        chunk_x -= c_search_region_extents;
-        chunk_z -= c_search_region_extents;
+        int32_t offset = chunk_x % 8;
+        if(i & 4 != 0) offset = 8 - offset;
+        chunk_x += -c_search_region_extents;
+        chunk_z += -c_search_region_extents + offset;
 
         cache.clear();
         // Stack is left empty after every call to explore_cluster(...), so there's no need to clear it here.

--- a/src/main.cu
+++ b/src/main.cu
@@ -144,7 +144,7 @@ __global__ void kernel(uint64_t block_count, uint64_t offset, uint64_t *collecto
         // Stack is left empty after every call to explore_cluster(...), so there's no need to clear it here.
         Cluster cluster = explore_cluster(cache, stack, rand, world_seed, chunk_x, chunk_z);
         if(cluster.get_size() >= c_min_cluster_size) {
-            uint64_t collector_idx = atomicAdd((unsigned long long*) collector_size, 1);
+            uint64_t collector_idx = atomicAdd(collector_size, 1);
             collector[collector_idx] = cluster;
         }
     }


### PR DESCRIPTION
added make target for linux
use diagonal grid search pattern so less chunks are searched

tested with `./slime-clusters -e 4096 -c 15` which outputs the same results as before even though a cluster could fit within the 25 cell grid.